### PR TITLE
feat: Implement Web Search toggle and max results selection

### DIFF
--- a/Android/src/app/build.gradle.kts
+++ b/Android/src/app/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
   implementation(libs.camerax.view)
   implementation(libs.openid.appauth)
   implementation(libs.androidx.splashscreen)
+  implementation("com.squareup.okhttp3:okhttp:4.12.0")
   testImplementation(libs.junit)
   androidTestImplementation(libs.androidx.junit)
   androidTestImplementation(libs.androidx.espresso.core)

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/WebSearchService.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/WebSearchService.kt
@@ -35,7 +35,7 @@ class WebSearchService {
                     put("query", query)
                     put("search_depth", "basic")
                     put("include_answer", true)
-                    put("max_results", maxResults) // Use the parameter here
+                    put("max_results", maxResults)
                     // include_domains and exclude_domains are empty by default
                 }.toString()
 

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/WebSearchService.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/WebSearchService.kt
@@ -1,0 +1,100 @@
+package com.google.ai.edge.gallery.data
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.IOException
+
+data class TavilySearchResult(
+    val title: String,
+    val url: String,
+    val content: String,
+    val score: Double
+)
+
+data class TavilySearchResponse(
+    val answer: String?,
+    val query: String?,
+    val results: List<TavilySearchResult>?
+)
+
+class WebSearchService {
+
+    private val client = OkHttpClient()
+
+    suspend fun search(apiKey: String, query: String, maxResults: Int): TavilySearchResponse? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val jsonRequestBody = JSONObject().apply {
+                    // api_key is passed via Bearer token in the header, so removed from body
+                    put("query", query)
+                    put("search_depth", "basic")
+                    put("include_answer", true)
+                    put("max_results", maxResults) // Use the parameter here
+                    // include_domains and exclude_domains are empty by default
+                }.toString()
+
+                val request = Request.Builder()
+                    .url("https://api.tavily.com/search")
+                    .header("Authorization", "Bearer $apiKey")
+                    .header("Content-Type", "application/json")
+                    .post(jsonRequestBody.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull()))
+                    .build()
+
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Log.e("WebSearchService", "API Error: ${response.code} ${response.message}")
+                        return@withContext null
+                    }
+
+                    val responseBody = response.body?.string()
+                    if (responseBody == null) {
+                        Log.e("WebSearchService", "Empty response body")
+                        return@withContext null
+                    }
+
+                    parseTavilyResponse(responseBody)
+                }
+            } catch (e: IOException) {
+                Log.e("WebSearchService", "Network Error: ${e.message}", e)
+                null
+            } catch (e: Exception) {
+                Log.e("WebSearchService", "Error during search: ${e.message}", e)
+                null
+            }
+        }
+    }
+
+    private fun parseTavilyResponse(responseBody: String): TavilySearchResponse? {
+        return try {
+            val jsonObject = JSONObject(responseBody)
+            val answer = jsonObject.optString("answer", null)
+            val query = jsonObject.optString("query", null)
+
+            val resultsArray = jsonObject.optJSONArray("results")
+            val searchResults = mutableListOf<TavilySearchResult>()
+            if (resultsArray != null) {
+                for (i in 0 until resultsArray.length()) {
+                    val resultObj = resultsArray.getJSONObject(i)
+                    searchResults.add(
+                        TavilySearchResult(
+                            title = resultObj.getString("title"),
+                            url = resultObj.getString("url"),
+                            content = resultObj.getString("content"),
+                            score = resultObj.getDouble("score")
+                        )
+                    )
+                }
+            }
+            TavilySearchResponse(answer, query, if (searchResults.isEmpty()) null else searchResults)
+        } catch (e: Exception) {
+            Log.e("WebSearchService", "Error parsing JSON response: ${e.message}", e)
+            null
+        }
+    }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/ViewModelProvider.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/ViewModelProvider.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.ai.edge.gallery.GalleryApplication
+import com.google.ai.edge.gallery.data.WebSearchService
 import com.google.ai.edge.gallery.ui.imageclassification.ImageClassificationViewModel
 import com.google.ai.edge.gallery.ui.imagegeneration.ImageGenerationViewModel
 import com.google.ai.edge.gallery.ui.llmchat.LlmChatViewModel
@@ -32,13 +33,19 @@ import com.google.ai.edge.gallery.ui.textclassification.TextClassificationViewMo
 
 object ViewModelProvider {
   val Factory = viewModelFactory {
+    // Create an instance of WebSearchService
+    // This instance will be shared by ViewModels that need it.
+    val webSearchService = WebSearchService()
+    // Get DataStoreRepository instance
+    val dataStoreRepository = galleryApplication().container.dataStoreRepository
+
     // Initializer for ModelManagerViewModel.
     initializer {
       val downloadRepository = galleryApplication().container.downloadRepository
-      val dataStoreRepository = galleryApplication().container.dataStoreRepository
+      // val dataStoreRepository = galleryApplication().container.dataStoreRepository // Already got it above
       ModelManagerViewModel(
         downloadRepository = downloadRepository,
-        dataStoreRepository = dataStoreRepository,
+        dataStoreRepository = dataStoreRepository, // Use the shared instance
         context = galleryApplication().container.context,
       )
     }
@@ -55,17 +62,25 @@ object ViewModelProvider {
 
     // Initializer for LlmChatViewModel.
     initializer {
-      LlmChatViewModel()
+      LlmChatViewModel(
+          webSearchService = webSearchService,
+          dataStoreRepository = dataStoreRepository // Pass it here
+      )
     }
 
-    // Initializer for LlmSingleTurnViewModel..
+    // Initializer for LlmSingleTurnViewModel.
+    // Note: LlmSingleTurnViewModel's constructor was not modified in previous steps.
+    // If it also needs WebSearchService in the future, its initializer and constructor would need similar changes.
     initializer {
       LlmSingleTurnViewModel()
     }
 
     // Initializer for LlmAskImageViewModel.
     initializer {
-      LlmAskImageViewModel()
+      LlmAskImageViewModel(
+          webSearchService = webSearchService,
+          dataStoreRepository = dataStoreRepository // Pass it here
+      )
     }
 
     // Initializer for ImageGenerationViewModel.

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/ViewModelProvider.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/ViewModelProvider.kt
@@ -36,7 +36,6 @@ object ViewModelProvider {
     // Create an instance of WebSearchService
     // This instance will be shared by ViewModels that need it.
     val webSearchService = WebSearchService()
-    // Get DataStoreRepository instance
     val dataStoreRepository = galleryApplication().container.dataStoreRepository
 
     // Initializer for ModelManagerViewModel.
@@ -63,8 +62,8 @@ object ViewModelProvider {
     // Initializer for LlmChatViewModel.
     initializer {
       LlmChatViewModel(
-          webSearchService = webSearchService,
-          dataStoreRepository = dataStoreRepository // Pass it here
+        webSearchService = webSearchService,
+        dataStoreRepository = dataStoreRepository,
       )
     }
 
@@ -78,8 +77,8 @@ object ViewModelProvider {
     // Initializer for LlmAskImageViewModel.
     initializer {
       LlmAskImageViewModel(
-          webSearchService = webSearchService,
-          dataStoreRepository = dataStoreRepository // Pass it here
+        webSearchService = webSearchService,
+        dataStoreRepository = dataStoreRepository,
       )
     }
 

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/llmchat/LlmChatViewModel.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/llmchat/LlmChatViewModel.kt
@@ -20,11 +20,14 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.google.ai.edge.gallery.BuildConfig // Import BuildConfig
 import com.google.ai.edge.gallery.data.ConfigKey
+import com.google.ai.edge.gallery.data.DataStoreRepository // Added
 import com.google.ai.edge.gallery.data.Model
 import com.google.ai.edge.gallery.data.TASK_LLM_CHAT
 import com.google.ai.edge.gallery.data.TASK_LLM_ASK_IMAGE
 import com.google.ai.edge.gallery.data.Task
+import com.google.ai.edge.gallery.data.WebSearchService
 import com.google.ai.edge.gallery.ui.common.chat.ChatMessageBenchmarkLlmResult
 import com.google.ai.edge.gallery.ui.common.chat.ChatMessageLoading
 import com.google.ai.edge.gallery.ui.common.chat.ChatMessageText
@@ -36,6 +39,7 @@ import com.google.ai.edge.gallery.ui.common.chat.Stat
 import com.google.ai.edge.gallery.ui.modelmanager.ModelManagerViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first // Added
 import kotlinx.coroutines.launch
 
 private const val TAG = "AGLlmChatViewModel"
@@ -46,10 +50,97 @@ private val STATS = listOf(
   Stat(id = "latency", label = "Latency", unit = "sec")
 )
 
-open class LlmChatViewModel(curTask: Task = TASK_LLM_CHAT) : ChatViewModel(task = curTask) {
+open class LlmChatViewModel(
+  curTask: Task = TASK_LLM_CHAT,
+  private val webSearchService: WebSearchService,
+  private val dataStoreRepository: DataStoreRepository // New parameter
+) : ChatViewModel(task = curTask) {
   fun generateResponse(model: Model, input: String, image: Bitmap? = null, onError: () -> Unit) {
     val accelerator = model.getStringConfigValue(key = ConfigKey.ACCELERATOR, defaultValue = "")
     viewModelScope.launch(Dispatchers.Default) {
+      val isWebSearchActuallyEnabled = dataStoreRepository.isWebSearchEnabledFlow.first()
+      var augmentedInput = input
+      var searchIndicatorMessage: ChatMessageLoading? = null // Used to remove the message later
+
+      if (isWebSearchActuallyEnabled) {
+        // --- Start of Web Search Block ---
+        searchIndicatorMessage = ChatMessageLoading(
+            text = "正在為您搜索網路獲取最新資訊...",
+            accelerator = accelerator,
+            side = ChatSide.AGENT
+        )
+        addMessage(model = model, message = searchIndicatorMessage)
+
+        var searchPerformed = false
+        var searchSuccessful = false
+        var searchErrorOccurred = false
+
+        try {
+          val apiKey = BuildConfig.TAVILY_API_KEY
+          if (apiKey.isEmpty() || apiKey == "YOUR_TAVILY_API_KEY_PLACEHOLDER") {
+            Log.e(TAG, "Tavily API Key is not configured or is still a placeholder.")
+            searchErrorOccurred = true
+            searchPerformed = true
+            searchSuccessful = false
+          } else {
+            // Get the stored maxResults value
+            val currentMaxResults = dataStoreRepository.webSearchMaxResultsFlow.first() // Default is 5 from DataStoreRepo
+
+            val tavilyResponse = webSearchService.search(
+                apiKey = apiKey,
+                query = input,
+                maxResults = currentMaxResults // Pass the stored value here
+            )
+            searchPerformed = true
+            if (tavilyResponse != null) {
+              searchSuccessful = true
+              val searchAnswer = tavilyResponse.answer
+              val searchResults = tavilyResponse.results
+
+              if (!searchAnswer.isNullOrBlank()) {
+                augmentedInput = "Based on web search results, answer the following: \"${searchAnswer}\". The original question was: \"${input}\""
+              } else if (!searchResults.isNullOrEmpty()) {
+                val snippets = searchResults.take(2).joinToString(separator = "; ") { it.content }
+                if (snippets.isNotBlank()) {
+                  augmentedInput = "Based on web search results, here are some relevant snippets: \"${snippets}\". The original question was: \"${input}\""
+                }
+              }
+            } else {
+              searchErrorOccurred = true // Or searchSuccessful = false depending on desired logic for null response
+            }
+          }
+        } catch (e: Exception) {
+          Log.e(TAG, "Web search call failed with exception", e)
+          searchErrorOccurred = true
+          if (!searchPerformed) { // Ensure searchPerformed is true if exception occurs
+              searchPerformed = true
+          }
+          searchSuccessful = false
+        }
+
+        // Remove search in-progress indicator
+        if (searchIndicatorMessage != null) {
+            val lastMessageCheck = getLastMessage(model = model)
+            if (lastMessageCheck == searchIndicatorMessage) {
+                removeLastMessage(model = model)
+            }
+        }
+        
+        // Add search result status messages
+        if (searchErrorOccurred) {
+            addMessage(
+                model = model,
+                message = ChatMessageWarning(content = "網路搜索失敗，將嘗試使用模型知識回答。")
+            )
+        } else if (searchPerformed && !searchSuccessful) {
+            addMessage(
+                model = model,
+                message = ChatMessageWarning(content = "網路搜索未能找到相關資訊，將嘗試使用模型知識回答。")
+            )
+        }
+        // --- End of Web Search Block ---
+      }
+
       setInProgress(true)
       setPreparing(true)
 
@@ -67,9 +158,11 @@ open class LlmChatViewModel(curTask: Task = TASK_LLM_CHAT) : ChatViewModel(task 
 
       // Run inference.
       val instance = model.instance as LlmModelInstance
-      var prefillTokens = instance.session.sizeInTokens(input)
+      var prefillTokens = instance.session.sizeInTokens(augmentedInput)
       if (image != null) {
-        prefillTokens += 257
+        // Assuming image context is added separately and not part of the text prompt for token calculation here.
+        // If image contributes to text prompt for LLM, this might need adjustment or be handled by the model instance.
+        prefillTokens += 257 // This is a magic number, ensure it's correct for multimodal inputs.
       }
 
       var firstRun = true
@@ -82,7 +175,7 @@ open class LlmChatViewModel(curTask: Task = TASK_LLM_CHAT) : ChatViewModel(task 
 
       try {
         LlmChatModelHelper.runInference(model = model,
-          input = input,
+          input = augmentedInput, // Use augmentedInput here
           image = image,
           resultListener = { partialResult, done ->
             val curTs = System.currentTimeMillis()
@@ -241,8 +334,16 @@ open class LlmChatViewModel(curTask: Task = TASK_LLM_CHAT) : ChatViewModel(task 
     )
 
     // Re-generate the response automatically.
+    // The original triggeredMessage.content will go through the search logic again.
     generateResponse(model = model, input = triggeredMessage.content, onError = {})
   }
 }
 
-class LlmAskImageViewModel : LlmChatViewModel(curTask = TASK_LLM_ASK_IMAGE)
+class LlmAskImageViewModel(
+    webSearchService: WebSearchService,
+    dataStoreRepository: DataStoreRepository // New parameter
+) : LlmChatViewModel(
+    curTask = TASK_LLM_ASK_IMAGE,
+    webSearchService = webSearchService,
+    dataStoreRepository = dataStoreRepository // Pass to super
+)

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/modelmanager/ModelManagerViewModel.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/modelmanager/ModelManagerViewModel.kt
@@ -55,6 +55,7 @@ import com.google.ai.edge.gallery.ui.llmchat.createLlmChatConfigs
 import com.google.ai.edge.gallery.ui.textclassification.TextClassificationModelHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -173,6 +174,26 @@ open class ModelManagerViewModel(
   override fun onCleared() {
     super.onCleared()
     authService.dispose()
+  }
+
+  // Expose Web Search enabled state Flow
+  val isWebSearchEnabledFlow: Flow<Boolean> = dataStoreRepository.isWebSearchEnabledFlow
+
+  // Provide method to update Web Search enabled state
+  fun setIsWebSearchEnabled(isEnabled: Boolean) {
+    viewModelScope.launch {
+      dataStoreRepository.setIsWebSearchEnabled(isEnabled)
+    }
+  }
+
+  // Expose Web Search max results Flow
+  val webSearchMaxResultsFlow: Flow<Int> = dataStoreRepository.webSearchMaxResultsFlow
+
+  // Provide method to update Web Search max results
+  fun setWebSearchMaxResults(count: Int) {
+    viewModelScope.launch {
+      dataStoreRepository.setWebSearchMaxResults(count)
+    }
   }
 
   fun selectModel(model: Model) {


### PR DESCRIPTION
- Securely manage API key via BuildConfig from local.properties.
- Add a toggle in SettingsDialog to enable/disable web search.
- Add a dropdown in SettingsDialog to select max search results (3, 5, 10, 20) when web search is enabled.
- Persist these settings using DataStoreRepository.
- LlmChatViewModel now respects these settings when performing web searches and constructing API calls.